### PR TITLE
可被连接的 Observable  => ConnectableObservable

### DIFF
--- a/content/decision_tree/connect.md
+++ b/content/decision_tree/connect.md
@@ -1,7 +1,7 @@
 ## connect
 
-**通知可被连接的 `Observable` 可以开始发出元素了**
+**通知 `ConnectableObservable` 可以开始发出元素了**
 
 ![](/assets/WhichOperator/Operators/publish.png)
 
-**可被连接的 `Observable`** 和普通的 `Observable` 十分相似，不过在被订阅后不会发出元素，直到 **connect** 操作符被应用为止。这样一来你可以等所有观察者全部订阅完成后，才发出元素。
+** `ConnectableObservable`** 和普通的 `Observable` 十分相似，不过在被订阅后不会发出元素，直到 **connect** 操作符被应用为止。这样一来你可以等所有观察者全部订阅完成后，才发出元素。


### PR DESCRIPTION
可被连接的 Observable 容易被误解， 建议还是使用  ConnectableObservable ， 让读者知道这是一个 class。